### PR TITLE
Add "shortcuts" to leave a comment and flag

### DIFF
--- a/Natty/NattyReporter.user.js
+++ b/Natty/NattyReporter.user.js
@@ -1,13 +1,13 @@
 // ==UserScript==
 // @name         Natty Reporter
 // @namespace    https://github.com/Tunaki/stackoverflow-userscripts
-// @version      0.13
+// @version      0.14
 // @description  Adds a Natty link below answers that sends a report for the bot in SOBotics. Intended to be used to give feedback on reports (true positive / false positive / needs edit) or report NAA/VLQ-flaggable answers.
 // @author       Tunaki
 // @include      /^https?:\/\/(www\.)?stackoverflow\.com\/.*/
 // @grant        GM_xmlhttpRequest
 // @require      http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
-// @downloadURL  https://github.com/SOBotics/Userscripts/blob/master/Natty/NattyReporter.user.js
+// @downloadURL  https://github.com/Tunaki/stackoverflow-userscripts/raw/master/NattyReporter.user.js
 // ==/UserScript==
 
 var room = 111347;
@@ -105,6 +105,60 @@ const ScriptToInject = function() {
     if (!confirm('Do you really want to report this post with feedback \'' + feedback + '\'?')) return false;
     window.postMessage(JSON.stringify(['postHrefReportNatty', postId, feedback]), "*");
   }
+    
+  function shortcutClicked(e) {
+    
+    var comments = {
+      'link-only':
+        'A link to a solution is welcome, but please ensure your answer is useful without it: ' + 
+        '[add context around the link](//meta.stackexchange.com/a/8259) so your fellow users will ' +
+        'have some idea what it is and why it’s there, then quote the most relevant part of the ' + 
+        'page you\'re linking to in case the target page is unavailable. ' +
+        '[Answers that are little more than a link may be deleted.](//stackoverflow.com/help/deleted-answers)',
+      'naa <50':
+        'This does not provide an answer to the question. You can [search for similar questions](//stackoverflow.com/search), ' +
+        'or refer to the related and linked questions on the right-hand side of the page to find an answer. ' +
+        'If you have a related but different question, [ask a new question](//stackoverflow.com/questions/ask), ' + 
+        'and include a link to this one to help provide context. ' +
+        'See: [Ask questions, get answers, no distractions](//stackoverflow.com/tour)',
+      'naa >50':
+        'This post doesn\'t look like an attempt to answer this question. Every post here is expected to be ' +
+        'an explicit attempt to *answer* this question; if you have a critique or need a clarification of ' +
+        'the question or another answer, you can [post a comment](//stackoverflow.com/help/privileges/comment) ' + 
+        '(like this one) directly below it. Please remove this answer and create either a comment or a new question. ' +
+        'See: [Ask questions, get answers, no distractions](//stackoverflow.com/tour)',
+      'thanks':
+        'Please don\'t add _"thanks"_ as answers. They don\'t actually provide an answer to the question, ' + 
+        'and can be perceived as noise by its future visitors. Once you [earn](http://meta.stackoverflow.com/q/146472) ' +
+        'enough [reputation](http://stackoverflow.com/help/whats-reputation), you will gain privileges to ' +
+        '[upvote answers](http://stackoverflow.com/help/privileges/vote-up) you like. This way future visitors of the question ' +
+        'will see a higher vote count on that answer, and the answerer will also be rewarded with reputation points. ' +
+        'See [Why is voting important](http://stackoverflow.com/help/why-vote).',
+      'me too':
+        'Please don\'t add *"Me too"* as answers. It doesn\'t actually provide an answer to the question. ' +
+        'If you have a different but related question, then [ask](//$SITEURL$/questions/ask) it ' +
+        '(reference this one if it will help provide context). If you\'re interested in this specific question, ' +
+        'you can [upvote](//stackoverflow.com/help/privileges/vote-up) it, leave a [comment](//stackoverflow.com/help/privileges/comment), ' +
+        'or start a [bounty](//stackoverflow.com/help/privileges/set-bounties) ' +
+        'once you have enough [reputation](//stackoverflow.com/help/whats-reputation).'
+    };
+      
+    e.preventDefault();
+    var postID = $(this).closest('div.post-menu').find('a.short-link').attr('id').split('-')[2];
+    
+    //flag the post (and report to Natty)
+    $.post('//stackoverflow.com/flags/posts/' + postID + '/add/AnswerNotAnAnswer', {'fkey': StackExchange.options.user.fkey, 'otherText': ''});
+    
+    //add a comment
+    var comment = comments[$(this).text()];
+    $.post('//stackoverflow.com/posts/' + postID + '/comments', {'fkey': StackExchange.options.user.fkey, 'comment': comment}, 
+      function(data, textStatus, jqXHR) {
+        var commentUI = StackExchange.comments.uiForPost($('#comments-' + postID));
+        commentUI.addShow(true, false);
+        commentUI.showComments(data, null, false, true);
+        $(document).trigger('comment', postID);
+    });
+  }
   
   function handleAnswers(postId) {
     var $posts;
@@ -117,7 +171,9 @@ const ScriptToInject = function() {
       var $this = $(this);
       $this.append($('<span>').attr('class', 'lsep').html('|'));
       var $dropdown = $('<dl>').css({ 'margin': '0', 'z-index': '1', 'position': 'absolute', 'white-space': 'nowrap', 'background': '#FFF' }).hide();
-      $.each(['tp', 'fp', 'ne'], function(i, val) { $dropdown.append($('<dd>').append($('<a>').css({ 'display': 'block', 'width': '35px' }).click(reportToNatty).text(val))); });
+      $.each(['tp', 'fp', 'ne'], function(i, val) { $dropdown.append($('<dd>').append($('<a>').css({ 'display': 'block', 'width': 'auto' }).click(reportToNatty).text(val))); });
+      $dropdown.append($('<hr>').css({'margin-bottom': '6.5px'}));
+      $.each(['link-only', 'naa <50', 'naa >50', 'thanks'], function(i, val) { $dropdown.append($('<dd>').append($('<a>').css({ 'display': 'block', 'width': 'auto' }).click(shortcutClicked).text(val))); });
       $this.append($('<a>').attr('class', 'report-natty-link').html('Natty').hover(function() { $dropdown.toggle(); }).append($dropdown));
     });
   };
@@ -158,4 +214,5 @@ document.body.appendChild(ScriptToInjectNode);
 
 const ScriptToInjectContent = document.createTextNode('(' + ScriptToInject.toString() + ')()');
 ScriptToInjectNode.appendChild(ScriptToInjectContent);
+
 

--- a/Natty/NattyReporter.user.js
+++ b/Natty/NattyReporter.user.js
@@ -7,7 +7,7 @@
 // @include      /^https?:\/\/(www\.)?stackoverflow\.com\/.*/
 // @grant        GM_xmlhttpRequest
 // @require      http://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js
-// @downloadURL  https://github.com/Tunaki/stackoverflow-userscripts/raw/master/NattyReporter.user.js
+// @downloadURL  https://github.com/SOBotics/Userscripts/blob/master/Natty/NattyReporter.user.js
 // ==/UserScript==
 
 var room = 111347;


### PR DESCRIPTION
I added "shortcut" options to the Natty menu, which leave an autocomment and cast a flag in one click.  The shortcuts I currently have are for link-only answers, NAA <50 rep, NAA >50 rep, and "thanks" answers, but we can add more shortcuts if we want.