### PR TITLE
Removed confirmation dialog for the old three feedback options

### DIFF
--- a/Natty/NattyReporter.user.js
+++ b/Natty/NattyReporter.user.js
@@ -102,7 +102,6 @@ const ScriptToInject = function() {
     if ($this.closest('a.natty-reported').length > 0) return false;
     var postId = $this.closest('div.post-menu').find('a.short-link').attr('id').split('-')[2];
     var feedback = $this.text();
-    if (!confirm('Do you really want to report this post with feedback \'' + feedback + '\'?')) return false;
     window.postMessage(JSON.stringify(['postHrefReportNatty', postId, feedback]), "*");
   }
     


### PR DESCRIPTION
This is
    a) More convenient for old, commonly deleted reports
    b) Consistent with the new options