### PR TITLE
Fix bug due to new 'share' button design

### DIFF
--- a/Natty/NattyReporter.user.js
+++ b/Natty/NattyReporter.user.js
@@ -161,7 +161,7 @@ const ScriptToInject = function() {
     };
       
     e.preventDefault();
-    var postID = $(this).closest('div.post-menu').find('a.short-link').attr('id').split('-')[2];
+    var postID = $(this).closest('div.post-menu').find('a.js-share-link').attr('href').split('/')[2];
     var whichFeedback = $(this).text();
     
     //flag the post (and report to Natty)

--- a/Natty/NattyReporter.user.js
+++ b/Natty/NattyReporter.user.js
@@ -110,7 +110,7 @@ const ScriptToInject = function() {
     e.preventDefault();
     var $this = $(this);
     if ($this.closest('a.natty-reported').length > 0) return false;
-    var postId = $this.closest('div.post-menu').find('a.short-link').attr('id').split('-')[2];
+    var postId = $this.closest('div.post-menu').find('a.js-share-link').attr('href').split('/')[2];
     var feedback = $this.text();
     window.postMessage(JSON.stringify(['postHrefReportNatty', postId, feedback]), "*");
   }


### PR DESCRIPTION
This fetches post id from 'share' `href`. There doesn't appear to be a `.short-link` class, too.