### PR TITLE
Adapt to new SE HTML changes

### DIFF
--- a/GenericBot/flagtracker.user.js
+++ b/GenericBot/flagtracker.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name          Stack Exchange Flag Tracker
 // @namespace     https://so.floern.com/
-// @version       1.2.1
+// @version       1.3
 // @description   Tracks flagged posts on Stack Exchange.
 // @author        Floern
 // @contributor   double-beep
@@ -27,8 +27,9 @@
   const myProfileElement = document.querySelector('.my-profile .gravatar-wrapper-24');
   const flaggername = myProfileElement ? myProfileElement.title : null;
   const sitename = window.location.hostname;
-  const lsepSpanHtml = ' <span class="lsep">|</span>';
-  const flagTrackerButtonHtml = '<a class="flag-tracker-link" title="register this post to be tracked">track</a>';
+  const flagTrackerButton = '<div class="grid--cell">'
+                            + '<button class="flag-tracker-link s-btn s-btn__link" title="register this post to be tracked">track</button>'
+                          + '</div>';
 
   function computeContentHash(postContent) {
     if (!postContent) return 0;
@@ -81,12 +82,10 @@
   }
 
   function handlePosts() {
-    [...document.querySelectorAll('.post-layout .post-menu')].forEach(element => {
+    [...document.querySelectorAll('.post-layout .js-post-menu')].forEach(element => {
       if (element.innerText.match('track')) return; // element already exists
-      element.insertAdjacentHTML('beforeend', ' ');
-      element.insertAdjacentHTML('beforeend', flagTrackerButtonHtml);
-      element.insertAdjacentHTML('beforeend', lsepSpanHtml);
-      element.querySelector('.flag-tracker-link').addEventListener('click', () => trackFlag(element));
+      element.children[0].insertAdjacentHTML('beforeend', flagTrackerButtonHtml);
+      element.children[0].querySelector('.flag-tracker-link').addEventListener('click', () => trackFlag(element));
     });
   }
 
@@ -99,7 +98,7 @@
     if (matches !== null && xhr.status === 200) {
       const postId = matches[1];
       const postIsQuestion = document.querySelector('.question').getAttribute('data-questionid') == postId;
-      const element = postIsQuestion ? document.querySelector('.question .post-menu') : document.querySelector(`#answer-${postId} .post-menu`);
+      const element = postIsQuestion ? document.querySelector('.question .js-post-menu') : document.querySelector(`#answer-${postId} .js-post-menu`);
       trackFlag(element);
     }
   });

--- a/GenericBot/flagtracker.user.js
+++ b/GenericBot/flagtracker.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name          Stack Exchange Flag Tracker
 // @namespace     https://so.floern.com/
-// @version       1.3
+// @version       1.4
 // @description   Tracks flagged posts on Stack Exchange.
 // @author        Floern
 // @contributor   double-beep
@@ -12,6 +12,7 @@
 // @match         *://*.askubuntu.com/*/*
 // @match         *://*.stackapps.com/*/*
 // @match         *://*.mathoverflow.net/*/*
+// @exclude       *://chat.*
 // @connect       so.floern.com
 // @require       https://greasemonkey.github.io/gm4-polyfill/gm4-polyfill.js
 // @grant         GM.xmlHttpRequest

--- a/Natty/SentinelLinks.js
+++ b/Natty/SentinelLinks.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        Sentinel Links 
 // @namespace   https://github.com/SOBotics/Userscripts
-// @version     0.01010
+// @version     0.01011
 // @description Adds a Sentinel link to answers
 // @author      Bhargav
 // @match       *://*.stackoverflow.com/*
@@ -11,7 +11,7 @@
 
 
 (function(){
-  $(".post-menu").each ( function (index) {
+  $(".js-share-link").parent().parent().each ( function (index) {
       var thisObj = $(this);
       var postLink  = thisObj.find('a[class="short-link"]').attr("href");
       if(postLink && postLink.indexOf('a')>=0){


### PR DESCRIPTION
Renames `.post-menu` to `.js-post-menu` and changes the HTML of the button.  
Excludes `chat.*` from flag tracker.